### PR TITLE
fairseq 0.12.2 :snowflake:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
 upload_channels:
   - sfe1ed40
-
 channels:
-- https://staging.continuum.io/prefect/fs/hydra-core-feedstock/pr2/72e53c2
+  - https://staging.continuum.io/prefect/fs/hydra-core-feedstock/pr2/72e53c2
+  - https://staging.continuum.io/prefect/fs/sacrebleu-feedstock/pr4/f1ce80e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - https://staging.continuum.io/prefect/fs/hydra-core-feedstock/pr2/72e53c2
-  - https://staging.continuum.io/prefect/fs/sacrebleu-feedstock/pr4/f1ce80e

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ upload_channels:
   - sfe1ed40
 
 channels:
-- https://staging.continuum.io/prefect/fs/hydra-core-feedstock/pr2/bfd1856
+- https://staging.continuum.io/prefect/fs/hydra-core-feedstock/pr2/72e53c2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+- https://staging.continuum.io/prefect/fs/hydra-core-feedstock/pr2/bfd1856

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+pytorch_variant:
+  - cpu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ requirements:
     - pytorch
     - cffi
     - cython
-    #- torchaudio >=0.8.0
+    - torchaudio >=0.8.0
 
 {% set tests_to_skip = " test_data_utils" %}
 
@@ -89,24 +89,24 @@ requirements:
 # RuntimeError: Mask Type should be defined
 # According to issue, fixed on main, but not in 0.12.2. 
 # https://github.com/facebookresearch/fairseq/issues/4858#issuecomment-1313135905
-{% set tests_to_skip = tests_to_skip + " or test_alignment" %}
-{% set tests_to_skip = tests_to_skip + " or test_alignment_full_context" %}
-{% set tests_to_skip = tests_to_skip + " or test_cmlm_transformer" %}
-{% set tests_to_skip = tests_to_skip + " or test_insertion_transformer" %}
-{% set tests_to_skip = tests_to_skip + " or test_iterative_nonautoregressive_transformer" %}
-{% set tests_to_skip = tests_to_skip + " or test_mixture_of_experts" %}
-{% set tests_to_skip = tests_to_skip + " or test_multilingual_transformer" %}
-{% set tests_to_skip = tests_to_skip + " or test_nonautoregressive_transformer" %}
-{% set tests_to_skip = tests_to_skip + " or test_transformer" %}
-{% set tests_to_skip = tests_to_skip + " or test_transformer_cross_self_attention" %}
-{% set tests_to_skip = tests_to_skip + " or test_transformer_pointer_generator" %}
-{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch" %}
-{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_dicts" %}
-{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_no_vepoch" %}
-{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_src_tgt_dict_spec" %}
-{% set tests_to_skip = tests_to_skip + " or test_activation_checkpointing_does_not_change_metrics" %}
-{% set tests_to_skip = tests_to_skip + " or test_activation_offloading_does_not_change_metrics" %}
-{% set tests_to_skip = tests_to_skip + " or test_mask_for_xformers" %}
+# {% set tests_to_skip = tests_to_skip + " or test_alignment" %}
+# {% set tests_to_skip = tests_to_skip + " or test_alignment_full_context" %}
+# {% set tests_to_skip = tests_to_skip + " or test_cmlm_transformer" %}
+# {% set tests_to_skip = tests_to_skip + " or test_insertion_transformer" %}
+# {% set tests_to_skip = tests_to_skip + " or test_iterative_nonautoregressive_transformer" %}
+# {% set tests_to_skip = tests_to_skip + " or test_mixture_of_experts" %}
+# {% set tests_to_skip = tests_to_skip + " or test_multilingual_transformer" %}
+# {% set tests_to_skip = tests_to_skip + " or test_nonautoregressive_transformer" %}
+# {% set tests_to_skip = tests_to_skip + " or test_transformer" %}
+# {% set tests_to_skip = tests_to_skip + " or test_transformer_cross_self_attention" %}
+# {% set tests_to_skip = tests_to_skip + " or test_transformer_pointer_generator" %}
+# {% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch" %}
+# {% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_dicts" %}
+# {% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_no_vepoch" %}
+# {% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_src_tgt_dict_spec" %}
+# {% set tests_to_skip = tests_to_skip + " or test_activation_checkpointing_does_not_change_metrics" %}
+# {% set tests_to_skip = tests_to_skip + " or test_activation_offloading_does_not_change_metrics" %}
+# {% set tests_to_skip = tests_to_skip + " or test_mask_for_xformers" %}
 
 #{% set tests_to_skip = tests_to_skip + " or test_roberta_incremental_decoder" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,50 +70,61 @@ requirements:
     - cffi
     - cython
     - torchaudio >=0.8.0
+  run_constrained:
+    - blas=*=openblas
+
+{% set tests_to_skip = "" %}
 
 {% set tests_to_skip = " test_data_utils" %}
-
-# missing CUDA error, but we don't need to build CUDA-compatible fairseq
+# # missing CUDA error, but we don't need to build CUDA-compatible fairseq
 {% set tests_to_skip = tests_to_skip + " or test_fp16_for_long_input" %}  # [pytorch_variant == "cpu"]
 
-# skipping because "soft_energy" KeyError that seems to be missing from a dict defined in files within examples/ directory 
+# # skipping because "soft_energy" KeyError that seems to be missing from a dict defined in files within examples/ directory 
 {% set tests_to_skip = tests_to_skip + " or test_expected_attention" %}   # [pytorch_variant == "cpu"]
 
-# skipping these because we don't have xformers
+# # skipping these because we don't have xformers
 {% set tests_to_skip = tests_to_skip + " or test_xformers_single_forward_parity" %}
 
-# skipping these because we don't have iopath
+# # skipping these because we don't have iopath
 {% set tests_to_skip = tests_to_skip + " or test_file_io_async" %}
 {% set tests_to_skip = tests_to_skip + " or test_xformers_single_forward_parity" %}
 
 # RuntimeError: Mask Type should be defined
 # According to issue, fixed on main, but not in 0.12.2. 
 # https://github.com/facebookresearch/fairseq/issues/4858#issuecomment-1313135905
-# {% set tests_to_skip = tests_to_skip + " or test_alignment" %}
-# {% set tests_to_skip = tests_to_skip + " or test_alignment_full_context" %}
-# {% set tests_to_skip = tests_to_skip + " or test_cmlm_transformer" %}
-# {% set tests_to_skip = tests_to_skip + " or test_insertion_transformer" %}
-# {% set tests_to_skip = tests_to_skip + " or test_iterative_nonautoregressive_transformer" %}
-# {% set tests_to_skip = tests_to_skip + " or test_mixture_of_experts" %}
-# {% set tests_to_skip = tests_to_skip + " or test_multilingual_transformer" %}
-# {% set tests_to_skip = tests_to_skip + " or test_nonautoregressive_transformer" %}
-# {% set tests_to_skip = tests_to_skip + " or test_transformer" %}
-# {% set tests_to_skip = tests_to_skip + " or test_transformer_cross_self_attention" %}
-# {% set tests_to_skip = tests_to_skip + " or test_transformer_pointer_generator" %}
-# {% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch" %}
-# {% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_dicts" %}
-# {% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_no_vepoch" %}
-# {% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_src_tgt_dict_spec" %}
-# {% set tests_to_skip = tests_to_skip + " or test_activation_checkpointing_does_not_change_metrics" %}
-# {% set tests_to_skip = tests_to_skip + " or test_activation_offloading_does_not_change_metrics" %}
-# {% set tests_to_skip = tests_to_skip + " or test_mask_for_xformers" %}
+{% set tests_to_skip = tests_to_skip + " or test_alignment" %}
+{% set tests_to_skip = tests_to_skip + " or test_alignment_full_context" %}
+{% set tests_to_skip = tests_to_skip + " or test_cmlm_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_insertion_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_iterative_nonautoregressive_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_mixture_of_experts" %}
+{% set tests_to_skip = tests_to_skip + " or test_multilingual_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_nonautoregressive_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_transformer_cross_self_attention" %}
+{% set tests_to_skip = tests_to_skip + " or test_transformer_pointer_generator" %}
+{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch" %}
+{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_dicts" %}
+{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_no_vepoch" %}
+{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_src_tgt_dict_spec" %}
+{% set tests_to_skip = tests_to_skip + " or test_activation_checkpointing_does_not_change_metrics" %}
+{% set tests_to_skip = tests_to_skip + " or test_activation_offloading_does_not_change_metrics" %}
+{% set tests_to_skip = tests_to_skip + " or test_mask_for_xformers" %}
 
-#{% set tests_to_skip = tests_to_skip + " or test_roberta_incremental_decoder" %}
+
+{% set tests_to_skip = tests_to_skip + " or test_laser_lstm" %}
+{% set tests_to_skip = tests_to_skip + " or test_laser_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_linformer_roberta_masked_lm" %}
+{% set tests_to_skip = tests_to_skip + " or test_linformer_roberta_regression_multiple" %}
+{% set tests_to_skip = tests_to_skip + " or test_linformer_roberta_regression_single" %}
+{% set tests_to_skip = tests_to_skip + " or test_linformer_roberta_sentence_prediction" %}
+{% set tests_to_skip = tests_to_skip + " or test_r4f_roberta" %}
+{% set tests_to_skip = tests_to_skip + " or test_waitk_checkpoint" %}
 
 test:
   source_files:
     - tests
-    - examples
+    #- examples
     - scripts
     - fairseq
   requires:
@@ -134,7 +145,9 @@ test:
     - fairseq-score --help
     - fairseq-train --help
     - fairseq-validate --help
-    - pytest -vv . -k "not({{ tests_to_skip }})"
+    #- pytest -vv . {{ test_files_to_skip }} -k "not({{ tests_to_skip }})"
+    #- pytest -vv . {{ test_files_to_skip }}
+    - pytest -vv .  --ignore=tests/speech_recognition/test_collaters.py --ignore=tests/speech_recognition/test_cross_entropy.py --ignore=tests/speech_recognition/test_data_utils.py --ignore=tests/speech_recognition/test_vggtransformer.py -k "not({{ tests_to_skip }})"
 
 about:
   home: https://github.com/pytorch/fairseq

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
     - fairseq-score = fairseq_cli.score:cli_main
     - fairseq-train = fairseq_cli.train:cli_main
     - fairseq-validate = fairseq_cli.validate:cli_main
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed
   skip: true  # [win or s390x]
   # fairseq still does not support python 3.11
   # https://github.com/facebookresearch/fairseq/pull/5359/files

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,8 +69,15 @@ test:
 about:
   home: https://github.com/pytorch/fairseq
   summary: Facebook AI Research Sequence-to-Sequence Toolkit
+  description: |
+    Fairseq(-py) is a sequence modeling toolkit that allows researchers and 
+    developers to train custom models for translation, summarization, language
+    modeling and other text generation tasks.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  dev_url: https://github.com/facebookresearch/fairseq
+  doc_url: https://fairseq.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,6 +60,14 @@ requirements:
     - bitarray
     - pytorch
 
+{% set tests_to_skip = "" %}
+# missing CUDA error, but we don't need to build CUDA-compatible fairseq
+{% set tests_to_skip = tests_to_skip + "test_fp16_for_long_input" %}  # [pytorch_variant == "cpu"]
+# skipping because "soft_energy" KeyError that seems to be missing from a dict defined in files within examples/ directory 
+{% set tests_to_skip = tests_to_skip + "test_expected_attention" %}   # [pytorch_variant == "cpu"]
+# skipping these because we don't have xformers
+{% set tests_to_skip = tests_to_skip + "test_xformers_single_forward_parity" %}
+
 test:
   source_files:
     - tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,8 +70,6 @@ requirements:
     - cffi
     - cython
     - torchaudio >=0.8.0
-  run_constrained:
-    - blas=*=openblas
 
 {% set tests_to_skip = "" %}
 
@@ -111,7 +109,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_activation_offloading_does_not_change_metrics" %}
 {% set tests_to_skip = tests_to_skip + " or test_mask_for_xformers" %}
 
-
+# requires examples, but skipping examples import due to segmentation fault from the size of examples
 {% set tests_to_skip = tests_to_skip + " or test_laser_lstm" %}
 {% set tests_to_skip = tests_to_skip + " or test_laser_transformer" %}
 {% set tests_to_skip = tests_to_skip + " or test_linformer_roberta_masked_lm" %}
@@ -126,7 +124,6 @@ requirements:
 test:
   source_files:
     - tests
-    #- examples
     - scripts
     - fairseq
   requires:
@@ -147,8 +144,6 @@ test:
     - fairseq-score --help
     - fairseq-train --help
     - fairseq-validate --help
-    #- pytest -vv . {{ test_files_to_skip }} -k "not({{ tests_to_skip }})"
-    #- pytest -vv . {{ test_files_to_skip }}
     - pytest -vv .  --ignore=tests/speech_recognition/test_collaters.py --ignore=tests/speech_recognition/test_cross_entropy.py --ignore=tests/speech_recognition/test_data_utils.py --ignore=tests/speech_recognition/test_vggtransformer.py -k "not({{ tests_to_skip }})"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -120,6 +120,8 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_linformer_roberta_sentence_prediction" %}
 {% set tests_to_skip = tests_to_skip + " or test_r4f_roberta" %}
 {% set tests_to_skip = tests_to_skip + " or test_waitk_checkpoint" %}
+{% set tests_to_skip = tests_to_skip + " or test_multilingual_translation_latent_depth" %}
+{% set tests_to_skip = tests_to_skip + " or test_roberta_incremental_decoder" %}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - pytorch
   run:
     - python
-    - hydra-core >=1.0.7 
+    - hydra-core >=1.0.7
     - omegaconf
     - {{ pin_compatible('numpy') }}
     - regex

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,12 @@ build:
     - fairseq-train = fairseq_cli.train:cli_main
     - fairseq-validate = fairseq_cli.validate:cli_main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed
+  missing_dso_whitelist:
+    - $RPATH/libtorch_cpu.so     # [linux]
+    - $RPATH/libtorch_cpu.dylib  # [osx]
+    - $RPATH/libtorch_python.so
+    - $RPATH/libc10
+    - $RPATH/libc10.so
   skip: true  # [win or s390x]
   # fairseq still does not support python 3.11
   # https://github.com/facebookresearch/fairseq/pull/5359/files

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: b5bb076f8b0d5b06a897b11627da278816752b2202650c34becd8f4240f86961
 
 build:
-  number: 6
+  number: 0
   entry_points:
     - fairseq-eval-lm = fairseq_cli.eval_lm:cli_main
     - fairseq-generate = fairseq_cli.generate:cli_main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,9 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   url: https://github.com/facebookresearch/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  #sha256: 34f1b18426bf3844714534162f065ab733e049597476daa35fffb4d06a92b524
   sha256: b5bb076f8b0d5b06a897b11627da278816752b2202650c34becd8f4240f86961
   patches:
     - patches/0001-remove-upper-bounds.patch
@@ -28,7 +26,6 @@ build:
     # compiling Cython token_block_utils_fast.pyx module so it can be imported
     - {{ PYTHON }} setup.py build_ext --inplace
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-    # - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --global-option="build_ext" --global-option="--inplace"
   missing_dso_whitelist:
     - $RPATH/libtorch_cpu.so         # [linux]
     - $RPATH/libtorch_cpu.dylib      # [osx]
@@ -55,7 +52,7 @@ requirements:
     - cython
     - setuptools
     - wheel
-    # It's required to build the CPP extensions.
+    # It's required to build the CPP extensions.q
     - pytorch
   run:
     - python
@@ -75,10 +72,10 @@ requirements:
 
 {% set tests_to_skip = " test_data_utils" %}
 # # missing CUDA error, but we don't need to build CUDA-compatible fairseq
-{% set tests_to_skip = tests_to_skip + " or test_fp16_for_long_input" %}  # [pytorch_variant == "cpu"]
+{% set tests_to_skip = tests_to_skip + " or test_fp16_for_long_input" %}
 
 # # skipping because "soft_energy" KeyError that seems to be missing from a dict defined in files within examples/ directory 
-{% set tests_to_skip = tests_to_skip + " or test_expected_attention" %}   # [pytorch_variant == "cpu"]
+{% set tests_to_skip = tests_to_skip + " or test_expected_attention" %}
 
 # # skipping these because we don't have xformers
 {% set tests_to_skip = tests_to_skip + " or test_xformers_single_forward_parity" %}
@@ -124,8 +121,7 @@ requirements:
 test:
   source_files:
     - tests
-    - scripts
-    - fairseq
+    - scripts/average_checkpoints.py
   requires:
     - pytest
     - hypothesis
@@ -144,10 +140,11 @@ test:
     - fairseq-score --help
     - fairseq-train --help
     - fairseq-validate --help
+    # all ignored tests are using examples, which causes segmentation when imported
     - pytest -vv .  --ignore=tests/speech_recognition/test_collaters.py --ignore=tests/speech_recognition/test_cross_entropy.py --ignore=tests/speech_recognition/test_data_utils.py --ignore=tests/speech_recognition/test_vggtransformer.py -k "not({{ tests_to_skip }})"
 
 about:
-  home: https://github.com/pytorch/fairseq
+  home: https://github.com/facebookresearch/fairseq
   summary: Facebook AI Research Sequence-to-Sequence Toolkit
   description: |
     Fairseq(-py) is a sequence modeling toolkit that allows researchers and 
@@ -157,7 +154,7 @@ about:
   license_file: LICENSE
   license_family: MIT
   dev_url: https://github.com/facebookresearch/fairseq
-  doc_url: https://fairseq.readthedocs.io/en/latest/
+  doc_url: https://fairseq.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
     - fairseq-score = fairseq_cli.score:cli_main
     - fairseq-train = fairseq_cli.train:cli_main
     - fairseq-validate = fairseq_cli.validate:cli_main
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:
     - $RPATH/libtorch_cpu.so         # [linux]
     - $RPATH/libtorch_cpu.dylib      # [osx]
@@ -51,7 +51,7 @@ requirements:
     - pytorch
   run:
     - python
-    - hydra-core >=1.0.7
+    - hydra-core >=1.0.7 
     - omegaconf
     - {{ pin_compatible('numpy') }}
     - regex
@@ -61,10 +61,22 @@ requirements:
     - pytorch
 
 test:
+  source_files:
+    - tests
+    - examples
+    - scripts
+    - fairseq
+    #- fairseq/data/data_utils_fast.pyx
+  requires:
+    - pytest
+    - hypothesis
+    - expecttest
+    - pip
   imports:
     - fairseq
     - fairseq.benchmark
   commands:
+    #- pip check
     - fairseq-eval-lm --help
     - fairseq-generate --help
     - fairseq-interactive --help
@@ -72,6 +84,7 @@ test:
     - fairseq-score --help
     - fairseq-train --help
     - fairseq-validate --help
+    - pytest -vv . --ignore=tests/test_data_utils.py
 
 about:
   home: https://github.com/pytorch/fairseq

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,15 @@
-{% set version = "0.12.3" %}
-
+{% set name = "fairseq" %}
+{% set version = "0.12.2" %}
 
 package:
   name: fairseq
   version: {{ version }}
 
 source:
-  url: https://github.com/pytorch/fairseq/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: f9e97dc0ff6a9f5c4f29fcf297c2fa4d16a2ca7f6dbd180286855e31e1cb3183
+  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://github.com/facebookresearch/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  #sha256: 34f1b18426bf3844714534162f065ab733e049597476daa35fffb4d06a92b524
+  sha256: b5bb076f8b0d5b06a897b11627da278816752b2202650c34becd8f4240f86961
 
 build:
   number: 6
@@ -28,20 +30,16 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
-    - pytorch                                # [build_platform != target_platform]
     - {{ compiler('c') }}
-    - {{ stdlib("c") }}
     - {{ compiler('cxx') }}
   host:
+    - pybind11
     - python
     - pip
     - numpy
     - cython
     - setuptools
+    - wheel
     # It's required to build the CPP extensions.
     - pytorch
   run:
@@ -53,6 +51,7 @@ requirements:
     - sacrebleu >=1.4.12
     - tqdm
     - bitarray
+    - pytorch
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   url: https://github.com/facebookresearch/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: b5bb076f8b0d5b06a897b11627da278816752b2202650c34becd8f4240f86961
   patches:
+      # following conda-forge pinnings.
     - patches/0001-remove-upper-bounds.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,8 @@ build:
   missing_dso_whitelist:
     - $RPATH/libtorch_cpu.so     # [linux]
     - $RPATH/libtorch_cpu.dylib  # [osx]
-    - $RPATH/libtorch_python.so
-    - $RPATH/libc10
-    - $RPATH/libc10.so
+    - $RPATH/libtorch_python.so  # [linux]
+    - $RPATH/libc10.so           # [linux]
   skip: true  # [win or s390x]
   # fairseq still does not support python 3.11
   # https://github.com/facebookresearch/fairseq/pull/5359/files
@@ -83,7 +82,7 @@ about:
   license_file: LICENSE
   license_family: MIT
   dev_url: https://github.com/facebookresearch/fairseq
-  doc_url: https://fairseq.readthedocs.io/
+  doc_url: https://fairseq.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,11 @@ build:
     - fairseq-score = fairseq_cli.score:cli_main
     - fairseq-train = fairseq_cli.train:cli_main
     - fairseq-validate = fairseq_cli.validate:cli_main
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    # compiling Cython token_block_utils_fast.pyx module so it can be imported
+    - {{ PYTHON }} setup.py build_ext --inplace
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    # - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --global-option="build_ext" --global-option="--inplace"
   missing_dso_whitelist:
     - $RPATH/libtorch_cpu.so         # [linux]
     - $RPATH/libtorch_cpu.dylib      # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,10 +24,12 @@ build:
     - fairseq-validate = fairseq_cli.validate:cli_main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed
   missing_dso_whitelist:
-    - $RPATH/libtorch_cpu.so     # [linux]
-    - $RPATH/libtorch_cpu.dylib  # [osx]
-    - $RPATH/libtorch_python.so  # [linux]
-    - $RPATH/libc10.so           # [linux]
+    - $RPATH/libtorch_cpu.so         # [linux]
+    - $RPATH/libtorch_cpu.dylib      # [osx]
+    - $RPATH/libtorch_python.so      # [linux]
+    - $RPATH/libc10.so               # [linux]
+    - $RPATH/libtorch_python.dylib   # [osx]
+    - $RPATH/libc10.dylib            # [osx]
   skip: true  # [win or s390x]
   # fairseq still does not support python 3.11
   # https://github.com/facebookresearch/fairseq/pull/5359/files

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ build:
     - fairseq-validate = fairseq_cli.validate:cli_main
   script:
     # compiling Cython token_block_utils_fast.pyx module so it can be imported
+    # https://github.com/facebookresearch/fairseq/blob/v0.12.2/.github/workflows/build.yml#L37
     - {{ PYTHON }} setup.py build_ext --inplace
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ build:
     - fairseq-train = fairseq_cli.train:cli_main
     - fairseq-validate = fairseq_cli.validate:cli_main
   script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [win]
+  skip: true  # [win or s390x]
   # fairseq still does not support python 3.11
   # https://github.com/facebookresearch/fairseq/pull/5359/files
   skip: true  # [py>=311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
   url: https://github.com/facebookresearch/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   #sha256: 34f1b18426bf3844714534162f065ab733e049597476daa35fffb4d06a92b524
   sha256: b5bb076f8b0d5b06a897b11627da278816752b2202650c34becd8f4240f86961
+  patches:
+    - patches/0001-remove-upper-bounds.patch
 
 build:
   number: 0
@@ -43,6 +45,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - pybind11
     - python
@@ -63,8 +67,12 @@ requirements:
     - tqdm
     - bitarray
     - pytorch
-#170 failed, 238 passed, 60 skipped, 4 deselected, 602 warnings
+    - cffi
+    - cython
+    #- torchaudio >=0.8.0
+
 {% set tests_to_skip = " test_data_utils" %}
+
 # missing CUDA error, but we don't need to build CUDA-compatible fairseq
 {% set tests_to_skip = tests_to_skip + " or test_fp16_for_long_input" %}  # [pytorch_variant == "cpu"]
 
@@ -76,9 +84,31 @@ requirements:
 
 # skipping these because we don't have iopath
 {% set tests_to_skip = tests_to_skip + " or test_file_io_async" %}
-
 {% set tests_to_skip = tests_to_skip + " or test_xformers_single_forward_parity" %}
-#{% set test_files_to_skip = " --ignore=tests/test_multihead_attention.py " %}
+
+# RuntimeError: Mask Type should be defined
+# According to issue, fixed on main, but not in 0.12.2. 
+# https://github.com/facebookresearch/fairseq/issues/4858#issuecomment-1313135905
+{% set tests_to_skip = tests_to_skip + " or test_alignment" %}
+{% set tests_to_skip = tests_to_skip + " or test_alignment_full_context" %}
+{% set tests_to_skip = tests_to_skip + " or test_cmlm_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_insertion_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_iterative_nonautoregressive_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_mixture_of_experts" %}
+{% set tests_to_skip = tests_to_skip + " or test_multilingual_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_nonautoregressive_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_transformer" %}
+{% set tests_to_skip = tests_to_skip + " or test_transformer_cross_self_attention" %}
+{% set tests_to_skip = tests_to_skip + " or test_transformer_pointer_generator" %}
+{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch" %}
+{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_dicts" %}
+{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_no_vepoch" %}
+{% set tests_to_skip = tests_to_skip + " or test_translation_multi_simple_epoch_src_tgt_dict_spec" %}
+{% set tests_to_skip = tests_to_skip + " or test_activation_checkpointing_does_not_change_metrics" %}
+{% set tests_to_skip = tests_to_skip + " or test_activation_offloading_does_not_change_metrics" %}
+{% set tests_to_skip = tests_to_skip + " or test_mask_for_xformers" %}
+
+#{% set tests_to_skip = tests_to_skip + " or test_roberta_incremental_decoder" %}
 
 test:
   source_files:
@@ -86,19 +116,17 @@ test:
     - examples
     - scripts
     - fairseq
-    #- fairseq/data/data_utils_fast.pyx
   requires:
     - pytest
     - hypothesis
     - expecttest
     - pip
-    # fairseq.tasks.text_to_speech
     - tensorboardx
   imports:
     - fairseq
     - fairseq.benchmark
   commands:
-    #- pip check
+    - pip check
     - fairseq-eval-lm --help
     - fairseq-generate --help
     - fairseq-interactive --help
@@ -106,7 +134,6 @@ test:
     - fairseq-score --help
     - fairseq-train --help
     - fairseq-validate --help
-    #- pytest -vv tests -vv {{ test_files_to_skip }} -k "not({{ tests_to_skip }})"
     - pytest -vv . -k "not({{ tests_to_skip }})"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,14 +63,22 @@ requirements:
     - tqdm
     - bitarray
     - pytorch
-
-{% set tests_to_skip = "" %}
+#170 failed, 238 passed, 60 skipped, 4 deselected, 602 warnings
+{% set tests_to_skip = " test_data_utils" %}
 # missing CUDA error, but we don't need to build CUDA-compatible fairseq
-{% set tests_to_skip = tests_to_skip + "test_fp16_for_long_input" %}  # [pytorch_variant == "cpu"]
+{% set tests_to_skip = tests_to_skip + " or test_fp16_for_long_input" %}  # [pytorch_variant == "cpu"]
+
 # skipping because "soft_energy" KeyError that seems to be missing from a dict defined in files within examples/ directory 
-{% set tests_to_skip = tests_to_skip + "test_expected_attention" %}   # [pytorch_variant == "cpu"]
+{% set tests_to_skip = tests_to_skip + " or test_expected_attention" %}   # [pytorch_variant == "cpu"]
+
 # skipping these because we don't have xformers
-{% set tests_to_skip = tests_to_skip + "test_xformers_single_forward_parity" %}
+{% set tests_to_skip = tests_to_skip + " or test_xformers_single_forward_parity" %}
+
+# skipping these because we don't have iopath
+{% set tests_to_skip = tests_to_skip + " or test_file_io_async" %}
+
+{% set tests_to_skip = tests_to_skip + " or test_xformers_single_forward_parity" %}
+#{% set test_files_to_skip = " --ignore=tests/test_multihead_attention.py " %}
 
 test:
   source_files:
@@ -84,6 +92,8 @@ test:
     - hypothesis
     - expecttest
     - pip
+    # fairseq.tasks.text_to_speech
+    - tensorboardx
   imports:
     - fairseq
     - fairseq.benchmark
@@ -96,7 +106,8 @@ test:
     - fairseq-score --help
     - fairseq-train --help
     - fairseq-validate --help
-    - pytest -vv . --ignore=tests/test_data_utils.py
+    #- pytest -vv tests -vv {{ test_files_to_skip }} -k "not({{ tests_to_skip }})"
+    - pytest -vv . -k "not({{ tests_to_skip }})"
 
 about:
   home: https://github.com/pytorch/fairseq

--- a/recipe/patches/0001-remove-upper-bounds.patch
+++ b/recipe/patches/0001-remove-upper-bounds.patch
@@ -1,0 +1,27 @@
+From 88b437f4af344473ba0dcc5c83afbe9bce482fb1 Mon Sep 17 00:00:00 2001
+From: Udo-Peter Steyer <ous8292@gmail.com>
+Date: Thu, 19 Sep 2024 12:20:49 -0500
+Subject: [PATCH] remove upper bounds
+
+---
+ setup.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index a7ce61a8..b639cbe7 100644
+--- a/setup.py
++++ b/setup.py
+@@ -200,8 +200,8 @@ def do_setup(package_data):
+             "cffi",
+             "cython",
+             'dataclasses; python_version<"3.7"',
+-            "hydra-core>=1.0.7,<1.1",
+-            "omegaconf<2.1",
++            "hydra-core>=1.0.7",
++            "omegaconf",
+             'numpy<1.20.0; python_version<"3.7"',
+             'numpy; python_version>="3.7"',
+             "regex",
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
fairseq 0.12.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4793]
- dev_url:        https://github.com/facebookresearch/fairseq/tree/v0.12.2
- conda_forge:    https://github.com/conda-forge/fairseq-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/fairseq/0.12.2
- pypi inspector: https://inspector.pypi.io/project/fairseq/0.12.2
- Dependency PR:
    - https://github.com/AnacondaRecipes/hydra-core-feedstock/pull/2
    - https://github.com/AnacondaRecipes/sacrebleu-feedstock/pull/4

### Explanation of changes:

- new version number
- Updated/rebuilt sacreblue and added setuptools_scm due to pip check failing, and saying it had a version of 0.0.0
- added Patch to remove upper bound
- skipped tests due to not importing tests/examples


[PKG-4793]: https://anaconda.atlassian.net/browse/PKG-4793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ